### PR TITLE
Handle ICE Portal's new non-connected behaviour

### DIFF
--- a/Sources/DBConnect/ICEDataController.swift
+++ b/Sources/DBConnect/ICEDataController.swift
@@ -44,6 +44,11 @@ public final class ICEDataController: NSObject, TrainDataController {
                     let trip = try decoder.decode(TripResponse.self, from: response.data)
                     completionHandler(trip, nil)
                 } catch DecodingError.dataCorrupted(let context) {
+                    if response.data.count == 0 {
+                        // iceportal.de outside WiFi returns 200 with an empty body.
+                        completionHandler(nil, TrainConnectionError.notConnected)
+                        break
+                    }
                     print(context)
                 } catch DecodingError.keyNotFound(let key, let context) {
                     print("Key '\(key)' not found:", context.debugDescription)
@@ -85,6 +90,11 @@ public final class ICEDataController: NSObject, TrainDataController {
                     let status = try decoder.decode(Status.self, from: response.data)
                     completionHandler(status, nil)
                 } catch DecodingError.dataCorrupted(let context) {
+                    if response.data.count == 0 {
+                        // iceportal.de outside WiFi returns 200 with an empty body.
+                        completionHandler(nil, TrainConnectionError.notConnected)
+                        break
+                    }
                     print(context)
                 } catch DecodingError.keyNotFound(let key, let context) {
                     print("Key '\(key)' not found:", context.debugDescription)
@@ -123,3 +133,4 @@ extension ICEDataController {
         return stop
     }
 }
+

--- a/Sources/TrainConnect/TrainDataController.swift
+++ b/Sources/TrainConnect/TrainDataController.swift
@@ -57,3 +57,7 @@ public class CombinedDataController: TrainDataController {
         }
     }
 }
+
+public enum TrainConnectionError: Error {
+    case notConnected
+}


### PR DESCRIPTION
ICE Portal on the internet has started returning HTTP 200 with an empty body, which causes the app to never show the "Please connect to WIFIonICE" prompt.

I now throw an error when I detect this response. The server on the train should never respond like this.

(If this is not clean enough, please suggest an alternative. This is my first time touching Swift. :D)